### PR TITLE
feat: add ignoreSuccess functionality for hooks

### DIFF
--- a/apps/api/src/manifest/manifest.controller.ts
+++ b/apps/api/src/manifest/manifest.controller.ts
@@ -132,23 +132,28 @@ export class ManifestController {
       }
 
       this.manifestService.setWebhookParamsValues(manifestResponse, payload);
+
       const dataWithUi = this.manifestService.getDataWithUiLabels(
         manifestResponse,
         payload,
       );
+
       const manifestWithPreSignatures =
         this.manifestService.addSignatureToPreHooks(
           manifestResponse,
           prehookSignaturesArray,
         );
+
       const preHooksResults = await this.manifestService.handlePreHooks(
         manifestWithPreSignatures.data.hooks.pre,
         this.secretKey,
       );
-      if (
+
+      const hasFailedPreHooks =
         preHooksResults &&
-        preHooksResults.filter((hook) => !hook.success).length > 0
-      ) {
+        preHooksResults.some((hook) => !hook.success && !hook.ignoreSuccess);
+
+      if (preHooksResults && hasFailedPreHooks) {
         return res.status(HttpStatus.BAD_REQUEST).json({
           validationResult: {
             success: false,
@@ -167,9 +172,12 @@ export class ManifestController {
         manifestWithPreSignatures.data.hooks.post,
       );
 
-      return res
-        .status(HttpStatus.OK)
-        .json({ validationResult, hook: { pre: preHooksResults } });
+      return res.status(HttpStatus.OK).json({
+        validationResult: {
+          success: true,
+        },
+        hook: { pre: preHooksResults },
+      });
     } catch (error) {
       if (error instanceof HmacError) {
         return res

--- a/apps/api/src/manifest/manifest.controller.ts
+++ b/apps/api/src/manifest/manifest.controller.ts
@@ -149,9 +149,9 @@ export class ManifestController {
         this.secretKey,
       );
 
-      const hasFailedPreHooks =
-        preHooksResults &&
-        preHooksResults.some((hook) => !hook.success && !hook.ignoreSuccess);
+      const hasFailedPreHooks = preHooksResults?.some(
+        (hook) => !hook.success && !hook.ignoreSuccess,
+      );
 
       if (preHooksResults && hasFailedPreHooks) {
         return res.status(HttpStatus.BAD_REQUEST).json({

--- a/apps/api/src/manifest/manifest.service.spec.ts
+++ b/apps/api/src/manifest/manifest.service.spec.ts
@@ -277,7 +277,9 @@ describe('ManifestService', () => {
 
     const result = await manifestService.handlePreHooks(hooks, secretKey);
 
-    expect(result).toEqual([{ signature: mockHmacValue, ...mockResponse }]);
+    expect(result).toEqual([
+      { signature: mockHmacValue, ignoreSuccess: false, ...mockResponse },
+    ]);
     expect(hookProcessorFactory.getProcessor).toHaveBeenCalledWith(
       hooks[0].factory,
     );

--- a/apps/api/src/manifest/manifest.service.ts
+++ b/apps/api/src/manifest/manifest.service.ts
@@ -47,7 +47,7 @@ export class ManifestService {
   ): Promise<PreHookResponse[]> {
     const preHookResult: PreHookResponse[] = [];
     for (const hook of hooks) {
-      const { signature, factory, params, id } = hook;
+      const { signature, factory, params, id, ignoreSuccess } = hook;
 
       let isHashValid = false;
       if (signature !== undefined && signature !== null && signature !== '') {
@@ -61,6 +61,7 @@ export class ManifestService {
         const newSignature = generateHmac({ factory, params }, secretKey);
         preHookResult.push({
           id,
+          ignoreSuccess,
           signature: newSignature,
           success: result?.success,
           ...result,
@@ -68,6 +69,7 @@ export class ManifestService {
       } else {
         preHookResult.push({
           id,
+          ignoreSuccess,
           success: false,
           message:
             'The pre-hook request was not sent because the signatures are the same',

--- a/apps/api/src/manifest/models/pre-hook-response.model.ts
+++ b/apps/api/src/manifest/models/pre-hook-response.model.ts
@@ -12,4 +12,5 @@ export class PreHookResponse {
   message?: string;
   factory?: HookType;
   params?: any;
+  ignoreSuccess: boolean;
 }

--- a/apps/api/src/models/hooks/hook.interface.ts
+++ b/apps/api/src/models/hooks/hook.interface.ts
@@ -5,4 +5,5 @@ export interface Hook {
   id: string;
   factory: HookType;
   params: HookParams;
+  ignoreSuccess: boolean;
 }

--- a/apps/api/src/queue/hook.queue.spec.ts
+++ b/apps/api/src/queue/hook.queue.spec.ts
@@ -61,6 +61,7 @@ describe('HookQueue', () => {
               },
             ],
           } as EmailRequest,
+          ignoreSuccess: false,
         },
       },
     } as { data: { hook: Hook } };
@@ -94,6 +95,7 @@ describe('HookQueue', () => {
               surname: faker.person.lastName(),
             },
           },
+          ignoreSuccess: false,
         },
       },
     } as { data: { hook: Hook } };
@@ -119,6 +121,7 @@ describe('HookQueue', () => {
           params: {
             ...webHookParams,
           },
+          ignoreSuccess: false,
         },
       },
     } as { data: { hook: Hook } };

--- a/apps/api/test/fixtures/manifest/hooks.fixture.ts
+++ b/apps/api/test/fixtures/manifest/hooks.fixture.ts
@@ -24,6 +24,9 @@ export class WebHookFixture implements Hook {
 
   @Mock(WebHookRequestFixture)
   params: WebHookRequestFixture;
+
+  @Mock(() => false)
+  ignoreSuccess: boolean;
 }
 
 export class EmailHookFixture implements Hook {
@@ -35,4 +38,7 @@ export class EmailHookFixture implements Hook {
 
   @Mock(EmailRequestFixture)
   params: EmailRequestFixture;
+
+  @Mock(() => false)
+  ignoreSuccess: boolean;
 }


### PR DESCRIPTION
Refactor hook interfaces and models to include 'ignoreSuccess' property