### PR TITLE
[DO_NOT_MERGE] chore: Update headers type in WebhookParams model

### DIFF
--- a/apps/api/src/manifest/manifest.controller.ts
+++ b/apps/api/src/manifest/manifest.controller.ts
@@ -131,7 +131,7 @@ export class ManifestController {
         throw new InvalidValidationError(validationResult);
       }
 
-      this.manifestService.setWebhookParamsValues(manifestResponse, payload);
+      this.manifestService.applyTemplateToHooks(manifestResponse, payload);
 
       const dataWithUi = this.manifestService.getDataWithUiLabels(
         manifestResponse,

--- a/apps/api/src/manifest/manifest.service.spec.ts
+++ b/apps/api/src/manifest/manifest.service.spec.ts
@@ -525,7 +525,7 @@ describe('ManifestService', () => {
         .spyOn(manifestService, 'transformPatternValues')
         .mockReturnValue(transformedPatternValues);
 
-      manifestService.setWebhookParamsValues(
+      manifestService.applyTemplateToHooks(
         manifest as TildaManifest,
         payload,
       );
@@ -555,7 +555,7 @@ describe('ManifestService', () => {
           TildaManifestFixture.getConstName2Value(),
       };
 
-      const generatedKeyValues = manifestService.generateWebhookKeyValues(
+      const generatedKeyValues = manifestService.generateHookTemplateKeyPairs(
         manifest as TildaManifest,
         payload,
       );
@@ -583,7 +583,7 @@ describe('ManifestService', () => {
           TildaManifestFixture.getConstName2Value(),
       };
 
-      const generatedKeyValues = manifestService.generateWebhookKeyValues(
+      const generatedKeyValues = manifestService.generateHookTemplateKeyPairs(
         manifest as TildaManifest,
         payload,
       );
@@ -611,7 +611,7 @@ describe('ManifestService', () => {
         surnameConstEncValue: '',
       };
 
-      const transformedPatternValues = manifestService.transformPatternValues(
+      const transformedPatternValues = manifestService.transformTemplateValues(
         (manifest.data.hooks.pre[0].params as WebhookParams).values,
         webhookKeyValues,
       );

--- a/apps/api/src/models/hooks/web-hook-params.model.ts
+++ b/apps/api/src/models/hooks/web-hook-params.model.ts
@@ -2,7 +2,7 @@ import { HookParams, WebhookHttpMethod } from '.';
 
 export interface WebhookParams extends HookParams {
   url: string;
-  headers?: string[];
+  headers?: { [key: string]: string };
   method: WebhookHttpMethod;
   values?: { [key: string]: string };
   success_path?: string;


### PR DESCRIPTION
Refactor the `headers` property in the `WebhookParams` model to use an object type instead of an array. This allows for more flexibility in specifying headers for webhook requests.